### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "node app.js"

--- a/README.md
+++ b/README.md
@@ -41,3 +41,5 @@
 >
 >![list_of_notes](/demo_gifs/deleting_a_tag.gif)
 >
+
+##[![Run on Repl.it](https://repl.it/badge/github/RonitKumar09/noteApp)](https://repl.it/github/RonitKumar09/noteApp)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).